### PR TITLE
Add additional number format constant for currency

### DIFF
--- a/Classes/PHPExcel/Style/NumberFormat.php
+++ b/Classes/PHPExcel/Style/NumberFormat.php
@@ -64,6 +64,7 @@ class PHPExcel_Style_NumberFormat extends PHPExcel_Style_Supervisor implements P
     const FORMAT_DATE_YYYYMMDDSLASH      = 'yy/mm/dd;@';
 
     const FORMAT_CURRENCY_USD_SIMPLE     = '"$"#,##0.00_-';
+    const FORMAT_CURRENCY_USD_ADVANCED   = '_("$"* #,##0.00_);_("$"* \(#,##0.00\);_("$"* "-"??_);_(@_)';
     const FORMAT_CURRENCY_USD            = '$#,##0_-';
     const FORMAT_CURRENCY_EUR_SIMPLE     = '[$EUR ]#,##0.00_-';
 


### PR DESCRIPTION
Added FORMAT_CURRENCY_USD_ADVANCED to replicate the format when you click the "Accounting Number Format" button in Excel